### PR TITLE
additional Helm flags handover

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ See full parameter documentation at deploy/action.yml
         release_name: my-release
         values_file: ./my-chart/values.yaml #optional
         set_string: test=1 #optional
+        additional_flags: --wait #optional
 ```
 
 ## License

--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -94,6 +94,8 @@ runs:
             UPGRADE_ARGS+=" --set-string ${{ inputs.set_string }}"
         fi
 
+        UPGRADE_ARGS+=" --wait"
+
         echo -n $UPGRADE_ARGS > /tmp/UPGRADE_ARGS
 
     - name: Helm | Release | Install

--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -38,6 +38,9 @@ inputs:
   kube_config:
     required: false
     description: Kubernetes custom config
+  additional_flags:
+    required: false
+    description: Additional flat flags
 runs:
   using: composite
   steps:
@@ -94,7 +97,10 @@ runs:
             UPGRADE_ARGS+=" --set-string ${{ inputs.set_string }}"
         fi
 
-        UPGRADE_ARGS+=" --wait"
+        if [ ! -z "${{ inputs.additional_flags }}" ]
+        then
+            UPGRADE_ARGS+=" ${{ inputs.additional_flags }}"
+        fi
 
         echo -n $UPGRADE_ARGS > /tmp/UPGRADE_ARGS
 


### PR DESCRIPTION
In order for an integration test job (triggered by Helm hook) to start only when the main program's pods are ready, I would need to be able to pass the "--wait" flag to helm-action/deploy. I would have made this rather simple in my submission and allowed quasi arbitrary flag concatenations in the additional_flags parameter (e.g. "--wait --debug --dry-run" or similar). Of course, this may be solved more stringently ;)