### PR TITLE
Save AdditionalFlags to env var

### DIFF
--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -79,6 +79,8 @@ runs:
         echo -n $RELEASE_NAME > /tmp/RELEASE_NAME
 
     - name: Helm | Release | Arguments
+      env:
+        ADDITIONAL_FLAGS: ${{ inputs.additional_flags }}
       shell: bash
       run: |
         if [ ! -z "${{ inputs.kube_config }}" ]
@@ -97,9 +99,9 @@ runs:
             UPGRADE_ARGS+=" --set-string ${{ inputs.set_string }}"
         fi
 
-        if [ ! -z "${{ inputs.additional_flags }}" ]
+        if [ ! -z "$ADDITIONAL_FLAGS" ]
         then
-            UPGRADE_ARGS+=" ${{ inputs.additional_flags }}"
+            UPGRADE_ARGS+=" $ADDITIONAL_FLAGS"
         fi
 
         echo -n $UPGRADE_ARGS > /tmp/UPGRADE_ARGS


### PR DESCRIPTION
the  ${{ inputs.additional_flags }} syntax basically acts like a string interpolation, which in the case of multiline strings will break inside a bash command. So it is now first saved to an env var, which is then referenced in the code